### PR TITLE
Update 0003-cluster-wide-machineconfigs.yaml.template

### DIFF
--- a/how-to-use-entitled-builds-with-ubi/0003-cluster-wide-machineconfigs.yaml.template
+++ b/how-to-use-entitled-builds-with-ubi/0003-cluster-wide-machineconfigs.yaml.template
@@ -47,7 +47,7 @@ spec:
     storage:
       files:
       - contents:
-          source: data:text/plain;charset=utf-8;base64,BASE64_ENCODED_PEM_FILE
+          source: data:text/plain;charset=utf-8;base64,BASE64_ENCODED_KEY_PEM_FILE
         filesystem: root
         mode: 0644
         path: /etc/pki/entitlement/entitlement-key.pem


### PR DESCRIPTION
🛈 If accepted, this would require changes to the blog post content.

The librhsm library included in `ubi8`, `ubi8-minimal`, and possibly others can become "confused" by both `entitlement.pem` and `entitlement-key.pem` including the same content. This library is used by `dnf` and `microdnf`.

From [rhsm-context.c](https://github.com/rpm-software-management/librhsm/blob/fcd972cbe7c8a3907ba9f091cd082b1090231492/rhsm/rhsm-context.c#L321), it will search the entitlement directory in an indeterminate order for the first `*.pem` file containing a section bounded by `-----BEGIN ENTITLEMENT DATA-----` and `-----END ENTITLEMENT DATA-----`. Then, in [rhsm-entitlement-certificate.c](https://github.com/rpm-software-management/librhsm/blob/fcd972cbe7c8a3907ba9f091cd082b1090231492/rhsm/rhsm-entitlement-certificate.c#L278) it will assume that the key is in an adjacent file with `-key` appended to the basename. 

In a cluster configured per the original blog, if librhsm first sees `entitlement.pem`, everything will be okay. If, however, librhsm sees `entitlement-key.pem` first, it will fail with the following error message, looking for `entitlement-key-key.pem`

```
error: cannot update repo 'rhel-8-for-x86_64-baseos-rpms': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried; Last error: Curl error (58): Problem with the local SSL certificate for https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/repodata/repomd.xml [unable to set private key file: '/etc/pki/entitlement-host/entitlement-key-key.pem' type PEM]
``` 